### PR TITLE
Add User Entity and Basic API Endpoint

### DIFF
--- a/user-service/src/main/java/com/tayyub/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/tayyub/userservice/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.tayyub.userservice.controller;
+
+
+import com.tayyub.userservice.entity.User;
+import com.tayyub.userservice.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @GetMapping
+    public List<User> getAllUsers(){
+        return userRepository.findAll();
+    }
+    @PostMapping
+    public User createUser(@RequestBody User user){
+        return userRepository.save(user);
+    }
+
+
+
+}

--- a/user-service/src/main/java/com/tayyub/userservice/entity/User.java
+++ b/user-service/src/main/java/com/tayyub/userservice/entity/User.java
@@ -1,0 +1,95 @@
+package com.tayyub.userservice.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+   @Column(nullable = false, unique = true)
+    private String username;
+
+   @Column(nullable = false, unique = true)
+   private String email;
+
+   @Column(nullable = false)
+   private String password;
+
+    private String profilePicture;
+    private String bio;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getProfilePicture() {
+        return profilePicture;
+    }
+
+    public void setProfilePicture(String profilePicture) {
+        this.profilePicture = profilePicture;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/user-service/src/main/java/com/tayyub/userservice/repository/UserRepository.java
+++ b/user-service/src/main/java/com/tayyub/userservice/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.tayyub.userservice.repository;
+
+
+import com.tayyub.userservice.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
This pull request introduces the foundational implementation for the User Service microservice, including the following:

    User Entity:
        Represents the users table in the database.
        Fields include id, username, email, password, profilePicture, bio, createdAt, and updatedAt.

    User Repository:
        Provides data access functionality using Spring Data JPA.
        Includes built-in CRUD methods for interacting with the database.

    User Controller:
        Exposes two RESTful API endpoints:
            GET /api/users: Fetches all users from the database.
            POST /api/users: Creates a new user in the database.

    Tested Functionality:
        Verified GET and POST endpoints using Postman.
        Database integration works as expected with the user_service_db PostgreSQL database.

    Other Details:
        Configured application.properties for the user-service project.
        Resolved initial database permissions issues by granting necessary privileges to the application user.